### PR TITLE
Add source-interface configuration to BGP peer configuration

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type peer struct {
 	ASN           uint32         `yaml:"peer-asn"`
 	Addr          string         `yaml:"peer-address"`
 	Port          uint16         `yaml:"peer-port"`
+	SrcIntf       string         `yaml:"source-interface"`
 	HoldTime      string         `yaml:"hold-time"`
 	RouterID      string         `yaml:"router-id"`
 	NodeSelectors []nodeSelector `yaml:"node-selectors"`
@@ -100,6 +101,8 @@ type Peer struct {
 	Addr net.IP
 	// Port to dial when establishing the session.
 	Port uint16
+	// Source interface to establish the BGP session from.
+	SrcIntf string
 	// Requested BGP hold time, per RFC4271.
 	HoldTime time.Duration
 	// BGP router ID to advertise to the peer
@@ -259,6 +262,11 @@ func parsePeer(p peer) (*Peer, error) {
 	if p.Port != 0 {
 		port = p.Port
 	}
+	var srcIntf string
+	if p.SrcIntf != "" {
+		srcIntf = p.SrcIntf
+	}
+
 	// Ideally we would set a default RouterID here, instead of having
 	// to do it elsewhere in the code. Unfortunately, we don't know
 	// the node IP here.
@@ -295,6 +303,7 @@ func parsePeer(p peer) (*Peer, error) {
 		ASN:           p.ASN,
 		Addr:          ip,
 		Port:          port,
+		SrcIntf:       srcIntf,
 		HoldTime:      holdTime,
 		RouterID:      routerID,
 		NodeSelectors: nodeSels,

--- a/speaker/bgp_controller.go
+++ b/speaker/bgp_controller.go
@@ -180,11 +180,15 @@ func (c *bgpController) syncPeers(l log.Logger) error {
 			// Session doesn't exist, but should be running. Create
 			// it.
 			l.Log("event", "peerAdded", "peer", p.cfg.Addr, "msg", "peer configured, starting BGP session")
+			srcIntf := ""
+			if p.cfg.SrcIntf != "" {
+				srcIntf = p.cfg.SrcIntf
+			}
 			var routerID net.IP
 			if p.cfg.RouterID != nil {
 				routerID = p.cfg.RouterID
 			}
-			s, err := newBGP(c.logger, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
+			s, err := newBGP(c.logger, srcIntf, net.JoinHostPort(p.cfg.Addr.String(), strconv.Itoa(int(p.cfg.Port))), p.cfg.MyASN, routerID, p.cfg.ASN, p.cfg.HoldTime, p.cfg.Password, c.myNode)
 			if err != nil {
 				l.Log("op", "syncPeers", "error", err, "peer", p.cfg.Addr, "msg", "failed to create BGP session")
 				errs++
@@ -286,6 +290,6 @@ func (c *bgpController) SetNode(l log.Logger, node *v1.Node) error {
 	return c.syncPeers(l)
 }
 
-var newBGP = func(logger log.Logger, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
-	return bgp.New(logger, addr, myASN, routerID, asn, hold, password, myNode)
+var newBGP = func(logger log.Logger, srcIntf string, addr string, myASN uint32, routerID net.IP, asn uint32, hold time.Duration, password string, myNode string) (session, error) {
+	return bgp.New(logger, srcIntf, addr, myASN, routerID, asn, hold, password, myNode)
 }


### PR DESCRIPTION
Add an optional "source-interface" parameter to the BGP peer
configuration.

When configured, this must be an interface name, and the BGP
session to the peer is sourced from that interface. This allows
the BGP session to originate from a Dummy interface (equivalent
to a Loopback interface on other BGP routers) rather than the
physical interface facing the BGP peer. This, in turn, can
help avoid conflicts when other processes (eg. Calico) are also
BGP peering off the same node.

Fixed #495.